### PR TITLE
error handling from the JS engine thru to the python interpreter. 

### DIFF
--- a/jsonata/__init__.py
+++ b/jsonata/__init__.py
@@ -3,6 +3,9 @@ import json as _json
 from _jsonata import Context as _llContext
 from _jsonata import transform as _lltransform
 
+class JsonataException(Exception):
+    pass
+
 def bigint_escape(data):
     """Escape big integers that JavaScript can't handle"""
     rval = data
@@ -59,12 +62,16 @@ class Context:
                             )
                         )
                     )
-        return _json.loads(
-                self._llcontext(
-                    xform,
-                    _json.dumps(data)
+        try:
+           return _json.loads(
+                    self._llcontext(
+                        xform,
+                        _json.dumps(data)
+                        )
                     )
-                )
+        except ValueError as e:
+            raise JsonataException(str(e))
+            
 
 def transform(xform, data, bigint_patch=False):
     """Convenience function for one-off JSONATA transforms"""

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -22,8 +22,11 @@ class DukContext {
     };
     std::string jsonata_call(std::string xform, std::string json_data) {
 	std::string command = std::string("JSON.stringify(jsonata('") + xform + std::string("').evaluate(") + json_data + std::string("));");
-        if (duk_peval_string(ctx, command.c_str()) != 0) {
-           throw std::invalid_argument("JSONATA command argument error");
+       
+        
+        if (duk_peval_string(ctx,command.c_str()) != 0) {
+            duk_to_object(ctx,-1);
+           throw pybind11::value_error(duk_json_encode(ctx,-1));//std::string("Error:") + 
 	}
 	return duk_safe_to_string(ctx, -1);
     }
@@ -35,6 +38,7 @@ std::string jsonata_wrapper_cpp(std::string xform, std::string json_data) {
 }
 
 PYBIND11_MODULE(_jsonata, m) {
+   
     m.doc() = "Python Wrapper for JDONata JavaScript library";
     m.def("transform", &jsonata_wrapper_cpp, "Apply JSONata transform to JSON data and returnt the result.",
           pybind11::arg("xform"), pybind11::arg("json_data"));


### PR DESCRIPTION
this pr adds support for passing the full JS stack and errors from the JS engine up thru the c layer, and finally to a JsonataException in Python instad of the generic "JSONATA command argument error" Exception.

much easier to debug without 3rd party tools, like the exerciser, now. 

some examples:

```
>>> import jsonata
>>> jncontext = jsonata.Context()
```


```
>>> result = jncontext('{"foo":$notAfunction()}', { "foo": "hi there", "bar": [1,2,3,5,8,13]})
Traceback (most recent call last):
 File "/Users/dominic.muscatella/jsonata-wrapper/jsonata/__init__.py", line 67, in __call__
  self._llcontext(
ValueError: {"code":"T1006","stack":"Error\n  at [anon] (eval:1) strict\n  at p (eval:1) strict\n  at [anon] (eval:1) strict tailcall\n  at p (eval:1) strict\n  at w (eval:1) strict\n  at [anon] (eval:1) strict tailcall\n  at p (eval:1) strict\n  at w (eval:1) strict\n  at [anon] (eval:1) strict tailcall","position":21,"token":"notAfunction","message":"Attempted to invoke a non-function"}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 File "/Users/dominic.muscatella/jsonata-wrapper/jsonata/__init__.py", line 73, in __call__
  raise JsonataException(str(e))
jsonata.JsonataException: {"code":"T1006","stack":"Error\n  at [anon] (eval:1) strict\n  at p (eval:1) strict\n  at [anon] (eval:1) strict tailcall\n  at p (eval:1) strict\n  at w (eval:1) strict\n  at [anon] (eval:1) strict tailcall\n  at p (eval:1) strict\n  at w (eval:1) strict\n  at [anon] (eval:1) strict tailcall","position":21,"token":"notAfunction","message":"Attempted to invoke a non-function"}
```

```
>>> result = jncontext('{"foo":$.bar', { "foo": "hi there", "bar": [1,2,3,5,8,13]})
Traceback (most recent call last):
 File "/Users/dominic.muscatella/jsonata-wrapper/jsonata/__init__.py", line 67, in __call__
  self._llcontext(
ValueError: {"code":"S0203","position":12,"token":"(end)","value":"}","stack":"Error\n  at [anon] (eval:1) strict tailcall\n  at [anon] (eval:1) strict\n  at [anon] (eval:1) strict\n  at [anon] (eval:1) strict\n  at Ce (eval:1) strict\n  at eval (eval:1) preventsyield","message":"Expected \"}\" before end of expression"}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 File "/Users/dominic.muscatella/jsonata-wrapper/jsonata/__init__.py", line 73, in __call__
  raise JsonataException(str(e))
jsonata.JsonataException: {"code":"S0203","position":12,"token":"(end)","value":"}","stack":"Error\n  at [anon] (eval:1) strict tailcall\n  at [anon] (eval:1) strict\n  at [anon] (eval:1) strict\n  at [anon] (eval:1) strict\n  at Ce (eval:1) strict\n  at eval (eval:1) preventsyield","message":"Expected \"}\" before end of expression"}
```

```
>>> result = jncontext('{"foo":$.bar}', { "foo": "hi there", "bar": [1,2,3,5,8,13]})
>>> print(result)
{'foo': [1, 2, 3, 5, 8, 13]}
```